### PR TITLE
feat(ui): add support for animated (*.gif) CatPacks

### DIFF
--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -445,13 +445,26 @@ void InstanceView::mouseDoubleClickEvent(QMouseEvent* event)
 void InstanceView::setPaintCat(bool visible)
 {
     m_catVisible = visible;
+
     if (visible) {
         auto catName = APPLICATION->themeManager()->getCatPack();
-        m_catPixmap.load(catName);
-        m_catIsScreenshot = catName.contains("screenshot");
-    } else {
-        m_catPixmap = QPixmap();
+        if (catName.endsWith(".gif")) {
+            m_catMovie = new QMovie(catName);
+            m_catMovie->setCacheMode(QMovie::CacheAll);
+            m_catMovie->setProperty("loopCount", "-1");
+            if (!m_catMovie->isValid()) {
+                qWarning() << "Invalid GIF file: " << catName;
+                m_catMovie = nullptr;
+            } else {
+                m_catMovie->start();
+            }
+            m_catIsScreenshot = false;
+        } else {
+            m_catPixmap.load(catName);
+            m_catIsScreenshot = catName.contains("screenshot");
+        }
     }
+    update(); // repaint
 }
 
 void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -466,7 +466,7 @@ void InstanceView::setPaintCat(bool visible)
                 delete m_catMovie;
                 m_catMovie = nullptr;
             } else {
-                connect(m_catMovie, &QMovie::frameChanged, this, QOverload<>::of(&InstanceView::update));
+                connect(m_catMovie, &QMovie::frameChanged, this, [this](int) { this->update(); });
                 m_catMovie->start();
             }
 

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -448,32 +448,38 @@ void InstanceView::setPaintCat(bool visible)
     m_catVisible = visible;
 
     if (visible) {
-    const QString& catName = APPLICATION->themeManager()->getCatPack();
-    if (catName.endsWith(".gif")) {
-        disconnect(m_catMovie, &QMovie::frameChanged, this, nullptr);
-        delete m_catMovie;
+        const QString& catName = APPLICATION->themeManager()->getCatPack();
 
-        m_catMovie = new QMovie(catName);
-        m_catMovie->setProperty("loopCount", -1);
-
-        if (!m_catMovie->isValid()) {
+        if (m_catMovie) {
+            disconnect(m_catMovie, &QMovie::frameChanged, this, nullptr);
             delete m_catMovie;
             m_catMovie = nullptr;
         } else {
-            connect(m_catMovie, &QMovie::frameChanged, this, QOverload<>::of(&InstanceView::update));
-            m_catMovie->start();
+            m_catPixmap = QPixmap();
         }
 
-        m_catIsScreenshot = false;
-    } else {
-        m_catPixmap = QPixmap();
-        m_catPixmap.load(catName);
-        // TODO: change "screenshot" to "fullscreen"
-        // ^^^^^ will be fixed with merge
-        m_catIsScreenshot = catName.contains("screenshot");
-    }
+        if (catName.endsWith(".gif")) {
+            m_catMovie = new QMovie(catName);
+            m_catMovie->setProperty("loopCount", -1);
 
-    update();  // repaint
+            if (!m_catMovie->isValid()) {
+                delete m_catMovie;
+                m_catMovie = nullptr;
+            } else {
+                connect(m_catMovie, &QMovie::frameChanged, this, QOverload<>::of(&InstanceView::update));
+                m_catMovie->start();
+            }
+
+            m_catIsScreenshot = false;
+        } else {
+            m_catPixmap = QPixmap();
+            m_catPixmap.load(catName);
+            // TODO: change "screenshot" to "fullscreen"
+            // ^^^^^ will be fixed with merge
+            m_catIsScreenshot = catName.contains("screenshot");
+        }
+
+        update();  // repaint
     } else {
         delete m_catMovie;
         m_catMovie = nullptr;

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -447,19 +447,11 @@ void InstanceView::setPaintCat(bool visible)
 {
     m_catVisible = visible;
 
-    if (!visible) {
-        m_catMovie->stop();
-        delete m_catMovie;
-        m_catMovie = nullptr;
-        m_catPixmap = QPixmap();
-        return;
-    }
-
+    if (visible) {
     const QString& catName = APPLICATION->themeManager()->getCatPack();
     if (catName.endsWith(".gif")) {
-        if (m_catMovie) {
-            delete m_catMovie;
-        }
+        disconnect(m_catMovie, &QMovie::frameChanged, this, nullptr);
+        delete m_catMovie;
 
         m_catMovie = new QMovie(catName);
         m_catMovie->setProperty("loopCount", -1);
@@ -474,12 +466,20 @@ void InstanceView::setPaintCat(bool visible)
 
         m_catIsScreenshot = false;
     } else {
+        m_catPixmap = QPixmap();
         m_catPixmap.load(catName);
         // TODO: change "screenshot" to "fullscreen"
+        // ^^^^^ will be fixed with merge
         m_catIsScreenshot = catName.contains("screenshot");
     }
 
     update();  // repaint
+    } else {
+        m_catMovie->stop();
+        delete m_catMovie;
+        m_catMovie = nullptr;
+        m_catPixmap = QPixmap();
+    }
 }
 
 void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -453,9 +453,12 @@ void InstanceView::setPaintCat(bool visible)
     m_catVisible = visible;
 
     if (!visible) {
-        delete m_catMovie;
-        m_catMovie = nullptr;
+        if (m_catMovie) {
+            delete m_catMovie;
+            m_catMovie = nullptr;
+        }
         m_catPixmap = QPixmap();
+        update();
         return;
     }
 

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -463,7 +463,7 @@ void InstanceView::setPaintCat(bool visible)
     }
 
     const QString& catName = APPLICATION->themeManager()->getCatPack();
-
+    emit catPackChanged();
     if (catName.endsWith(".gif")) {
         if (m_catMovie) {
             delete m_catMovie;
@@ -484,10 +484,21 @@ void InstanceView::setPaintCat(bool visible)
         m_catIsScreenshot = false;
     } else {
         m_catPixmap.load(catName);
+        // TODO: change "screenshot" to "fullscreen"
         m_catIsScreenshot = catName.contains("screenshot");
     }
 
     update(); // repaint
+}
+
+void InstanceView::updateCatPack()
+{
+    const QString& catName = APPLICATION->themeManager()->getCatPack();
+
+    if (!catName.isEmpty()) {
+        setPaintCat(m_catVisible);  // Перезагружаем отображение
+    }
+    update();  // Обновляем интерфейс
 }
 
 void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -458,6 +458,9 @@ void InstanceView::setPaintCat(bool visible)
             m_catMovie->setCacheMode(QMovie::CacheAll);
             m_catMovie->setProperty("loopCount", -1);
 
+            // TODO: change this
+            m_catMovie->setSpeed(10);
+
             if (!m_catMovie->isValid()) {
                 qWarning() << "Invalid GIF file: " << catName;
                 delete m_catMovie;
@@ -495,13 +498,7 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
         int widWidth = this->viewport()->width();
         int widHeight = this->viewport()->height();
 
-        if (m_catMovie) {
-            QImage currentFrame = m_catMovie->currentImage();
-            if (!currentFrame.isNull()) {
-                QRect targetRect(0, 0, widWidth, widHeight);
-                painter.drawImage(targetRect, currentFrame);
-            }
-        } else if (!m_catPixmap.isNull()) {
+        if (!m_catPixmap.isNull()) {
             if (m_catIsScreenshot) {
                 QPixmap pixmap = m_catPixmap.scaled(widWidth, widHeight, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
                 QRect rectOfPixmap = pixmap.rect();

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -498,7 +498,13 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
         int widWidth = this->viewport()->width();
         int widHeight = this->viewport()->height();
 
-        if (!m_catPixmap.isNull()) {
+        if (m_catMovie) {
+            QImage currentFrame = m_catMovie->currentImage();
+            if (!currentFrame.isNull()) {
+                QRect targetRect(0, 0, currentFrame.width(), currentFrame.height());
+                painter.drawImage(targetRect, currentFrame);
+            }
+        } else if (!m_catPixmap.isNull()) {
             if (m_catIsScreenshot) {
                 QPixmap pixmap = m_catPixmap.scaled(widWidth, widHeight, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
                 QRect rectOfPixmap = pixmap.rect();

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -474,9 +474,7 @@ void InstanceView::setPaintCat(bool visible)
         } else {
             m_catPixmap = QPixmap();
             m_catPixmap.load(catName);
-            // TODO: change "screenshot" to "fullscreen"
-            // ^^^^^ will be fixed with merge
-            m_catIsScreenshot = catName.contains("screenshot");
+            m_catIsScreenshot = catName.contains("screenshot", Qt::CaseInsensitive) || catName.contains("fullscreen", Qt::CaseInsensitive);
         }
 
         update();  // repaint

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -475,7 +475,6 @@ void InstanceView::setPaintCat(bool visible)
 
     update();  // repaint
     } else {
-        m_catMovie->stop();
         delete m_catMovie;
         m_catMovie = nullptr;
         m_catPixmap = QPixmap();

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -55,7 +55,6 @@
 #include <Application.h>
 #include <InstanceList.h>
 
-
 template <typename T>
 bool listsIntersect(const QList<T>& l1, const QList<T> t2)
 {
@@ -446,31 +445,23 @@ void InstanceView::mouseDoubleClickEvent(QMouseEvent* event)
 
 void InstanceView::setPaintCat(bool visible)
 {
-    if (m_catVisible == visible) {
-        return;
-    }
-
     m_catVisible = visible;
 
     if (!visible) {
-        if (m_catMovie) {
-            delete m_catMovie;
-            m_catMovie = nullptr;
-        }
+        m_catMovie->stop();
+        delete m_catMovie;
+        m_catMovie = nullptr;
         m_catPixmap = QPixmap();
-        update();
         return;
     }
 
     const QString& catName = APPLICATION->themeManager()->getCatPack();
-    emit catPackChanged();
     if (catName.endsWith(".gif")) {
         if (m_catMovie) {
             delete m_catMovie;
         }
 
         m_catMovie = new QMovie(catName);
-        m_catMovie->setCacheMode(QMovie::CacheAll);
         m_catMovie->setProperty("loopCount", -1);
 
         if (!m_catMovie->isValid()) {
@@ -488,17 +479,7 @@ void InstanceView::setPaintCat(bool visible)
         m_catIsScreenshot = catName.contains("screenshot");
     }
 
-    update(); // repaint
-}
-
-void InstanceView::updateCatPack()
-{
-    const QString& catName = APPLICATION->themeManager()->getCatPack();
-
-    if (!catName.isEmpty()) {
-        setPaintCat(m_catVisible);  // Перезагружаем отображение
-    }
-    update();  // Обновляем интерфейс
+    update();  // repaint
 }
 
 void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <qmovie.h>
 #include <QMovie>
 #include <QCache>
 #include <QLineEdit>
@@ -131,7 +132,7 @@ class InstanceView : public QAbstractItemView {
     mutable QCache<int, QRect> geometryCache;
     bool m_catVisible = false;
     QMovie* m_catMovie = nullptr;
-    QPixmap m_catPixmap;
+    QPixmap m_catPixmap = QPixmap();
     bool m_catIsScreenshot;
 
     // point where the currently active mouse action started in geometry coordinates

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -78,7 +78,6 @@ class InstanceView : public QAbstractItemView {
     virtual QRegion visualRegionForSelection(const QItemSelection& selection) const override;
 
     int spacing() const { return m_spacing; };
-    void updateCatPack();
     void setPaintCat(bool visible);
 
    public slots:
@@ -95,7 +94,6 @@ class InstanceView : public QAbstractItemView {
    signals:
     void droppedURLs(QList<QUrl> urls);
     void groupStateChanged(QString group, bool collapsed);
-    void catPackChanged();
 
    protected:
     bool isIndexHidden(const QModelIndex& index) const override;

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -79,6 +79,7 @@ class InstanceView : public QAbstractItemView {
     virtual QRegion visualRegionForSelection(const QItemSelection& selection) const override;
 
     int spacing() const { return m_spacing; };
+    void updateCatPack()
     void setPaintCat(bool visible);
 
    public slots:
@@ -95,6 +96,7 @@ class InstanceView : public QAbstractItemView {
    signals:
     void droppedURLs(QList<QUrl> urls);
     void groupStateChanged(QString group, bool collapsed);
+    void catPackChanged();
 
    protected:
     bool isIndexHidden(const QModelIndex& index) const override;

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -35,7 +35,6 @@
 
 #pragma once
 
-#include <qmovie.h>
 #include <QMovie>
 #include <QCache>
 #include <QLineEdit>
@@ -79,7 +78,7 @@ class InstanceView : public QAbstractItemView {
     virtual QRegion visualRegionForSelection(const QItemSelection& selection) const override;
 
     int spacing() const { return m_spacing; };
-    void updateCatPack()
+    void updateCatPack();
     void setPaintCat(bool visible);
 
    public slots:

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <QMovie>
 #include <QCache>
 #include <QLineEdit>
 #include <QListView>
@@ -129,6 +130,7 @@ class InstanceView : public QAbstractItemView {
     int m_currentCursorColumn = -1;
     mutable QCache<int, QRect> geometryCache;
     bool m_catVisible = false;
+    QMovie* m_catMovie = nullptr;
     QPixmap m_catPixmap;
     bool m_catIsScreenshot;
 

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -76,6 +76,12 @@ JsonCatPack::PartialDate partialDate(QJsonObject date)
     return { month, day };
 };
 
+GifCatPack::GifCatPack(const QFileInfo& fileInfo) : BasicCatPack(fileInfo.dir().dirName()) {
+    m_name = fileInfo.baseName();
+    m_path = fileInfo.absoluteFilePath();
+    m_movie = new QMovie(m_path);
+}
+
 JsonCatPack::JsonCatPack(QFileInfo& manifestInfo) : BasicCatPack(manifestInfo.dir().dirName())
 {
     QString path = manifestInfo.path();

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -82,6 +82,26 @@ GifCatPack::GifCatPack(const QFileInfo& fileInfo) : BasicCatPack(fileInfo.dir().
     m_movie = new QMovie(m_path);
 }
 
+void GifCatPack::displayCat(QPainter& painter)
+{
+    if (!m_movie) {
+        return;
+    }
+
+    if (m_movie->state() != QMovie::Running) {
+        m_movie->start();
+    }
+
+    QImage currentFrame = m_movie->currentImage();
+
+    if (!currentFrame.isNull()) {
+        QRect targetRect(0, 0, currentFrame.width(), currentFrame.height());
+        painter.drawImage(targetRect, currentFrame);  // Отображаем кадр на экране
+    } else {
+        qWarning() << "Failed to get current frame from the GIF";
+    }
+}
+
 JsonCatPack::JsonCatPack(QFileInfo& manifestInfo) : BasicCatPack(manifestInfo.dir().dirName())
 {
     QString path = manifestInfo.path();

--- a/launcher/ui/themes/CatPack.h
+++ b/launcher/ui/themes/CatPack.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <QPainter>
+#include <QMovie>
 #include <QDate>
 #include <QFileInfo>
 #include <QList>
@@ -69,6 +71,23 @@ class FileCatPack : public BasicCatPack {
 
    private:
     QString m_path;
+};
+
+class GifCatPack : public BasicCatPack {
+   public:
+    GifCatPack(const QFileInfo& fileInfo);
+
+    virtual QString id() override { return m_id; }
+    virtual QString name() override { return m_name; }
+    virtual QString path() override { return m_path; }
+
+    void displayCat(QPainter& painter);
+
+   private:
+    QString m_id;
+    QString m_name;
+    QString m_path;
+    QMovie* m_movie;
 };
 
 class JsonCatPack : public BasicCatPack {

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -314,6 +314,10 @@ void ThemeManager::initializeCatPacks()
     for (auto format : QImageReader::supportedImageFormats()) {
         supportedImageFormats.append("*." + format);
     }
+
+    // add gif support
+    supportedImageFormats.append("*.gif");
+
     auto loadFiles = [this, supportedImageFormats](QDir dir) {
         // Load image files directly
         QDirIterator ImageFileIterator(dir.absoluteFilePath(""), supportedImageFormats, QDir::Files);
@@ -321,7 +325,13 @@ void ThemeManager::initializeCatPacks()
             QFile customCatFile(ImageFileIterator.next());
             QFileInfo customCatFileInfo(customCatFile);
             themeDebugLog() << "Loading CatPack from:" << customCatFileInfo.absoluteFilePath();
-            addCatPack(std::unique_ptr<CatPack>(new FileCatPack(customCatFileInfo)));
+
+            if (customCatFileInfo.suffix() == "gif") {
+                addCatPack(std::unique_ptr<CatPack>(new GifCatPack(customCatFileInfo)));
+            } else {
+                addCatPack(std::unique_ptr<CatPack>(new FileCatPack(customCatFileInfo)));
+            }
+
         }
     };
 


### PR DESCRIPTION
# Description of changes:

1.    Handling Animated Files (*.gif):
        The setPaintCat function was updated to handle .gif files using the QMovie class for animation.
        When the path to the CatPack points to a .gif file, a QMovie object is created to manage the animation, and the frame loop is started with the loopCount set to -1 for infinite looping.

2.    Handling Static Images:
        For non-.gif files (e.g., .png, .jpg), the QPixmap class is used for loading and displaying static images.

## Benefits of the changes:

-    Added support for animated CatPacks in the .gif format.
-    The code is now more flexible and optimized for handling various image formats.