### PR TITLE
fix(ui): fix animated CatPacks for built in backgrounds

### DIFF
--- a/launcher/resources/backgrounds/backgrounds.qrc
+++ b/launcher/resources/backgrounds/backgrounds.qrc
@@ -2,7 +2,7 @@
 <RCC version="1.0">
     <qresource prefix="/backgrounds">
         <file alias="miside-screenshot">miside-screenshot.png</file>
-        <file alias="maxwell-christmas">maxwell-christmas.gif</file>
+        <file alias="maxwell-christmas-gif">maxwell-christmas.gif</file>
         <file alias="typescript">typescript.png</file>
         <file alias="kitteh">kitteh.png</file>
         <file alias="kitteh-xmas">kitteh-xmas.png</file>

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -458,7 +458,7 @@ void InstanceView::setPaintCat(bool visible)
             m_catPixmap = QPixmap();
         }
 
-        if (catName.endsWith(".gif")) {
+        if (catName.endsWith(".gif") || catName.endsWith("-gif")) {
             m_catMovie = new QMovie(catName);
             m_catMovie->setProperty("loopCount", -1);
 

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -82,6 +82,13 @@ GifCatPack::GifCatPack(const QFileInfo& fileInfo) : BasicCatPack(fileInfo.dir().
     m_movie = new QMovie(m_path);
 }
 
+GifCatPack::GifCatPack(QString id, QString name) : BasicCatPack(id)
+{
+    m_name = name;
+    m_path = QString(":/backgrounds/%1").arg(id);
+    m_movie = new QMovie(m_path);
+}
+
 void GifCatPack::displayCat(QPainter& painter)
 {
     if (!m_movie) {

--- a/launcher/ui/themes/CatPack.h
+++ b/launcher/ui/themes/CatPack.h
@@ -76,6 +76,7 @@ class FileCatPack : public BasicCatPack {
 class GifCatPack : public BasicCatPack {
    public:
     GifCatPack(const QFileInfo& fileInfo);
+    GifCatPack(QString id, QString name);
 
     virtual QString id() override { return m_id; }
     virtual QString name() override { return m_name; }

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -305,7 +305,11 @@ void ThemeManager::initializeCatPacks()
                                                     { "rory-flat", QObject::tr("Rory ID 11 (flat edition, drawn by Ashtaka)") },
                                                     { "teawie", QObject::tr("Teawie (drawn by SympathyTea)") } };
     for (auto [id, name] : defaultCats) {
-        addCatPack(std::unique_ptr<CatPack>(new BasicCatPack(id, name)));
+        if (id.endsWith("-gif")) {
+            addCatPack(std::unique_ptr<CatPack>(new GifCatPack(id, name)));
+        } else {
+            addCatPack(std::unique_ptr<CatPack>(new BasicCatPack(id)));
+        }
     }
     if (!m_catPacksFolder.mkpath("."))
         themeWarningLog() << "Couldn't create catpacks folder";

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -300,7 +300,7 @@ void ThemeManager::initializeCatPacks()
     QList<std::pair<QString, QString>> defaultCats{ { "kitteh", QObject::tr("Background Cat (from MultiMC)") },
                                                     { "typescript", QObject::tr("You should have used Typescript") },
                                                     { "miside-screenshot", QObject::tr("MiSide Screenshot") },
-                                                    { "maxwell-christmas", QObject::tr("Maxwell Christmas Cat.gif") },
+                                                    { "maxwell-christmas-gif", QObject::tr("Maxwell Christmas Cat") },
                                                     { "rory", QObject::tr("Rory ID 11 (drawn by Ashtaka)") },
                                                     { "rory-flat", QObject::tr("Rory ID 11 (flat edition, drawn by Ashtaka)") },
                                                     { "teawie", QObject::tr("Teawie (drawn by SympathyTea)") } };

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -300,12 +300,16 @@ void ThemeManager::initializeCatPacks()
     QList<std::pair<QString, QString>> defaultCats{ { "kitteh", QObject::tr("Background Cat (from MultiMC)") },
                                                     { "typescript", QObject::tr("You should have used Typescript") },
                                                     { "miside-screenshot", QObject::tr("MiSide Screenshot") },
-                                                    { "maxwell-christmas", QObject::tr("Maxwell Christmas Cat") },
+                                                    { "maxwell-christmas", QObject::tr("Maxwell Christmas Cat Gif") },
                                                     { "rory", QObject::tr("Rory ID 11 (drawn by Ashtaka)") },
                                                     { "rory-flat", QObject::tr("Rory ID 11 (flat edition, drawn by Ashtaka)") },
                                                     { "teawie", QObject::tr("Teawie (drawn by SympathyTea)") } };
     for (auto [id, name] : defaultCats) {
-        addCatPack(std::unique_ptr<CatPack>(new BasicCatPack(id, name)));
+        if (name.contains("Gif")) {
+            addCatPack(std::unique_ptr<CatPack>(new GifCatPack(id, name)));
+        } else {
+            addCatPack(std::unique_ptr<CatPack>(new BasicCatPack(id, name)));
+        }
     }
     if (!m_catPacksFolder.mkpath("."))
         themeWarningLog() << "Couldn't create catpacks folder";

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -300,16 +300,12 @@ void ThemeManager::initializeCatPacks()
     QList<std::pair<QString, QString>> defaultCats{ { "kitteh", QObject::tr("Background Cat (from MultiMC)") },
                                                     { "typescript", QObject::tr("You should have used Typescript") },
                                                     { "miside-screenshot", QObject::tr("MiSide Screenshot") },
-                                                    { "maxwell-christmas", QObject::tr("Maxwell Christmas Cat Gif") },
+                                                    { "maxwell-christmas", QObject::tr("Maxwell Christmas Cat.gif") },
                                                     { "rory", QObject::tr("Rory ID 11 (drawn by Ashtaka)") },
                                                     { "rory-flat", QObject::tr("Rory ID 11 (flat edition, drawn by Ashtaka)") },
                                                     { "teawie", QObject::tr("Teawie (drawn by SympathyTea)") } };
     for (auto [id, name] : defaultCats) {
-        if (name.contains("Gif")) {
-            addCatPack(std::unique_ptr<CatPack>(new GifCatPack(id, name)));
-        } else {
-            addCatPack(std::unique_ptr<CatPack>(new BasicCatPack(id, name)));
-        }
+        addCatPack(std::unique_ptr<CatPack>(new BasicCatPack(id, name)));
     }
     if (!m_catPacksFolder.mkpath("."))
         themeWarningLog() << "Couldn't create catpacks folder";


### PR DESCRIPTION
#### Changes:
1. **Fixed support for animated GIFs in built in CatPack.**
   - Updated logic in `ThemeManager::initializeCatPacks()` to check for the `-gif` suffix to determine whether to use `GifCatPack` instead of the standard `BasicCatPack`.

1. **Data updates:**
   - Changed "Maxwell Christmas Cat"  ID from `maxwell-christmas` to `maxwell-christmas-gif`, enabling it to be processed correctly as a `GifCatPack`.

#### Testing:
- Verified that static images continue to function as expected.
- Confirmed that animated GIFs load and render without errors.
