### PR TITLE
fix(msa): fix not working automatic msa auth

### DIFF
--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -67,29 +67,11 @@ bool isSchemeHandlerRegistered()
     return true;
 }
 
-class CustomOAuthOobReplyHandler : public QOAuthOobReplyHandler {
-    Q_OBJECT
-
-   public:
-    explicit CustomOAuthOobReplyHandler(QObject* parent = nullptr) : QOAuthOobReplyHandler(parent)
-    {
-        connect(APPLICATION, &Application::oauthReplyRecieved, this, &QOAuthOobReplyHandler::callbackReceived);
-    }
-    ~CustomOAuthOobReplyHandler() override
-    {
-        disconnect(APPLICATION, &Application::oauthReplyRecieved, this, &QOAuthOobReplyHandler::callbackReceived);
-    }
-    QString callback() const override { return BuildConfig.LAUNCHER_APP_BINARY_NAME + "://oauth/microsoft"; }
-};
-
 MSAStep::MSAStep(AccountData* data, bool silent) : AuthStep(data), m_silent(silent)
 {
     m_clientId = APPLICATION->getMSAClientID();
-    if (QCoreApplication::applicationFilePath().startsWith("/tmp/.mount_") || APPLICATION->isPortable() || !APPLICATION->isPortable() || !isSchemeHandlerRegistered())
-
-    {
-        auto replyHandler = new QOAuthHttpServerReplyHandler(this);
-        replyHandler->setCallbackText(QString(R"XXX(
+    auto replyHandler = new QOAuthHttpServerReplyHandler(this);
+    replyHandler->setCallbackText(QString(R"XXX(
     <noscript>
       <meta http-equiv="Refresh" content="0; URL=%1" />
     </noscript>
@@ -97,12 +79,8 @@ MSAStep::MSAStep(AccountData* data, bool silent) : AuthStep(data), m_silent(sile
     <script>
       window.location.replace("%1");
     </script>
-    )XXX")
-                                          .arg(BuildConfig.LOGIN_CALLBACK_URL));
-        oauth2.setReplyHandler(replyHandler);
-    } else {
-        oauth2.setReplyHandler(new CustomOAuthOobReplyHandler(this));
-    }
+    )XXX").arg(BuildConfig.LOGIN_CALLBACK_URL));
+    oauth2.setReplyHandler(replyHandler);
     oauth2.setAuthorizationUrl(QUrl("https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize"));
     oauth2.setAccessTokenUrl(QUrl("https://login.microsoftonline.com/consumers/oauth2/v2.0/token"));
     oauth2.setScope("XboxLive.SignIn XboxLive.offline_access");

--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -85,7 +85,7 @@ class CustomOAuthOobReplyHandler : public QOAuthOobReplyHandler {
 MSAStep::MSAStep(AccountData* data, bool silent) : AuthStep(data), m_silent(silent)
 {
     m_clientId = APPLICATION->getMSAClientID();
-    if (QCoreApplication::applicationFilePath().startsWith("/tmp/.mount_") || APPLICATION->isPortable() || !isSchemeHandlerRegistered())
+    if (QCoreApplication::applicationFilePath().startsWith("/tmp/.mount_") || APPLICATION->isPortable() || !APPLICATION->isPortable() || !isSchemeHandlerRegistered())
 
     {
         auto replyHandler = new QOAuthHttpServerReplyHandler(this);


### PR DESCRIPTION
#### Changes:
1. **Fixed not working automatic MSA auth in setup versions of Freesm Launcher.**
   - Forced non-portable versions to use `localhost` auth method;
   - Removed unused `CustomOAuthOobReplyHandler` class.

#### Testing:
- Verified that MSA auth works in both setup and portable versions of MSVC and MinGW.
- Checked that MSA auth works on macOS builds (thanks [so5iso4ka](https://github.com/so5iso4ka)!)
- Ensured that MSA auth is not broken in Linux versions.
- Confirmed that these commits don't break offline accounts.