### PR TITLE
feat: show cmake building platform info and user's system id in the user agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,8 +181,8 @@ set(Launcher_FMLLIBS_BASE_URL "https://files.prismlauncher.org/fmllibs/" CACHE S
 
 ######## Set version numbers ########
 set(Launcher_VERSION_MAJOR 1)
-set(Launcher_VERSION_MINOR 0)
-set(Launcher_VERSION_PATCH 0)
+set(Launcher_VERSION_MINOR 1)
+set(Launcher_VERSION_PATCH 1)
 set(Launcher_VERSION_CODENAME "Sequoia")
 
 set(Launcher_VERSION_NAME "${Launcher_VERSION_CODENAME}-${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.${Launcher_VERSION_PATCH}")

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1776,7 +1776,10 @@ QString Application::getUserAgent()
         return uaOverride.replace("$LAUNCHER_VER", BuildConfig.printableVersionString());
     }
 
-    return BuildConfig.USER_AGENT;
+    QByteArray uaKey = QSysInfo::machineUniqueId();
+    QString uaKeyString = QString(uaKey);
+
+    return BuildConfig.USER_AGENT + uaKeyString;
 }
 
 QString Application::getUserAgentUncached()
@@ -1787,7 +1790,10 @@ QString Application::getUserAgentUncached()
         return uaOverride.replace("$LAUNCHER_VER", BuildConfig.printableVersionString());
     }
 
-    return BuildConfig.USER_AGENT_UNCACHED;
+    QByteArray uaKey = QSysInfo::machineUniqueId();
+    QString uaKeyString = QString(uaKey);
+
+    return BuildConfig.USER_AGENT_UNCACHED + uaKeyString;
 }
 
 bool Application::handleDataMigration(const QString& currentData,

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -18,7 +18,7 @@ set(Launcher_Copyright "© 2024-2025 Freesm Launcher Contributors\\n© 2022-2024
 set(Launcher_Copyright_Mac "© 2024-2025 Freesm Launcher Contributors, © 2022-2024 Prism Launcher Contributors, © 2021-2022 PolyMC Contributors and © 2012-2021 MultiMC Contributors" PARENT_SCOPE)
 set(Launcher_Copyright "${Launcher_Copyright}" PARENT_SCOPE)
 set(Launcher_Domain "https://github.com/FreesmTeam/FreesmLauncher" PARENT_SCOPE)
-set(Launcher_UserAgent "${Launcher_CommonName}/${Launcher_VERSION_NAME}" PARENT_SCOPE)
+set(Launcher_UserAgent "${Launcher_CommonName}/${Launcher_VERSION_NAME} (${CMAKE_SYSTEM}; ${CMAKE_SYSTEM_NAME}; ${CMAKE_SYSTEM_PROCESSOR}) " PARENT_SCOPE)
 set(Launcher_ConfigFile "freesmlauncher.cfg" PARENT_SCOPE)
 set(Launcher_Git "https://github.com/FreesmTeam/FreesmLauncher" PARENT_SCOPE)
 set(Launcher_DesktopFileName "org.freesmTeam.freesmlauncher.desktop" PARENT_SCOPE)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/07d0330e-47dc-4b3b-a2ae-608468514f09)

CMake building platform info is detected at build time thanks to CMakelists variables, user's system id is provided by `QSysInfo::machineUniqueId()`

By storing these user agents in a database (on every /feed request), we can see the approximate number of freesmlauncher users, including filtering by OS

For those who are interested, this is truly **privacy-friendly, bloatware-less, no glowies, suckless change**.