### PR TITLE
fix(libraries): prevent dangling reference in ely libs override

### DIFF
--- a/launcher/minecraft/launch/ApplyLibraryOverrides.cpp
+++ b/launcher/minecraft/launch/ApplyLibraryOverrides.cpp
@@ -57,8 +57,8 @@ void ApplyLibraryOverrides::onLibraryOverrideDownloadFinished()
             continue;
         }
 
-        auto versionRef = artifactRef.toObject()[library->version()];
-        if (!versionRef.isObject()) {
+        auto version = artifactRef.toObject().value(library->version());
+        if (!version.isObject()) {
             continue;
         }
 
@@ -67,7 +67,7 @@ void ApplyLibraryOverrides::onLibraryOverrideDownloadFinished()
             continue;
         }
 
-        auto override = versionRef.toObject();
+        auto override = version.toObject();
         auto newDownloadInfo = std::make_shared<MojangDownloadInfo>();
         newDownloadInfo->url = override["url"].toString();
         newDownloadInfo->sha1 = override["sha1"].toString();


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/Freesmteam/FreesmLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
