### PR TITLE
fix(nix): removing windstone as nix package maintainer

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -105,7 +105,6 @@ assert lib.assertMsg (
       '';
       maintainers = with lib.maintainers; [
         s0me1newithhand7s
-        windstone
       ];
     };
   }


### PR DESCRIPTION
quick hotfix