### PR TITLE
ci(cachix): run cachix builds on flake.lock updates

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -7,7 +7,6 @@ on:
     paths-ignore:
       - "docs"
       - "**.md"
-      - "flake.lock"
       - "packages"
       - ".github/ISSUE_TEMPLATE"
       - ".markdownlint"


### PR DESCRIPTION
Right now cachix builds are not triggered on `flake.lock` updates. Therefore, those builds become outdated.

Turns out, the `cachix.yml` action ignores `flake.lock` path updates, so I removed that line to fix the provided problem.