### PR TITLE
chore(nix): remove unnecessary PIE hardening flag

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -68,10 +68,6 @@ assert lib.assertMsg (
       ]
       ++ lib.optional gamemodeSupport gamemode;
 
-    hardeningEnable = lib.optionals stdenv.hostPlatform.isLinux [
-      "pie"
-    ];
-
     cmakeFlags =
       [
         (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")


### PR DESCRIPTION
This flag is no longer needed, because `nixpkgs` include it by default according to this evaluation warning:
```
evaluation warning: The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future.
```

We should remove it, because that will become an error in the future.