### PR TITLE
chore(nix): exclude empty submodule directories in `nix-filter` to reduce cache misses in Garnix CI

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -38,10 +38,20 @@ assert lib.assertMsg (
         ../docs/COPYING.md
         ../CMakeLists.txt
       ];
+
+      # Sometimes these directories (submodules) exist but are empty instead of being absent, which can cause cache misses in Garnix CI.
+      # Maybe we don't know the entire truth...
+      exclude = [
+        "libraries/cmark"
+        "libraries/extra-cmake-modules"
+        "libraries/quazip"
+        "libraries/tomlplusplus"
+        "libraries/zlib"
+        "libraries/libnbtplusplus"
+      ];
     };
 
     postUnpack = ''
-      rm -rf source/libraries/libnbtplusplus
       ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
     '';
 


### PR DESCRIPTION
Testing shows that empty submodule directories cause cache misses in Garnix CI. Excluding them resolves the issue. (though the solution might not be perfect...)

Fixes: https://github.com/FreesmTeam/FreesmLauncher/issues/102