### PR TITLE
chore(nix): include jdk25

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -42,14 +42,8 @@ assert lib.assertMsg (
         ../CMakeLists.txt
       ];
 
-      # Sometimes these directories (submodules) exist but are empty instead of being absent, which can cause cache misses in Garnix CI.
-      # Maybe we don't know the entire truth...
+      # Some fetchers leave submodules directories empty instead of omitting them, causing Garnix CI cache misses.
       exclude = [
-        "libraries/cmark"
-        "libraries/extra-cmake-modules"
-        "libraries/quazip"
-        "libraries/tomlplusplus"
-        "libraries/zlib"
         "libraries/libnbtplusplus"
       ];
     };

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -6,6 +6,7 @@
   glfw3-minecraft,
   jdk17,
   jdk21,
+  jdk25,
   jdk8,
   kdePackages,
   lib,
@@ -34,6 +35,7 @@
   controllerSupport ? stdenv.hostPlatform.isLinux,
   gamemodeSupport ? stdenv.hostPlatform.isLinux,
   jdks ? [
+    jdk25
     jdk21
     jdk17
     jdk8


### PR DESCRIPTION
starting from 26.1 version, java 25 is required, it would be nice to include it by default