### PR TITLE
fix(nix): Update java paths env

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -120,7 +120,7 @@ in
         ++ additionalPrograms;
     in
       [
-        "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
+        "--prefix FREESMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [
         "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/Freesmteam/FreesmLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
I use Nix to install Freesm and after installing [v2.2.0](https://github.com/FreesmTeam/FreesmLauncher/releases/tag/2.2.0), the launcher would not detect the java paths.

So I looked into it, and the fix is to rename `PRISMLAUNCHER_JAVA_PATHS` to `FREESMLAUNCHER_JAVA_PATHS`.