### PR TITLE
Launcher comparison table update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,13 +62,12 @@ Based on Prism Launcher **11.0.2**
 ## Comparison
 
 
-| Feature                                  | Freesm  Launcher | Shattered  Prism | HMCL | Fjord   | PollyMC       | ElyPrism      | UltimMC | Prism-Cracked | Prism Launcher |
+| Feature                                  | Freesm  Launcher | Shattered  Prism | HMCL | Fjord   | PollyMC       | PineconeMC      | UltimMC | Prism-Cracked | Prism Launcher |
 |------------------------------------------|------------------|------------------|------|---------|---------------|---------------|---------|---------------|----------------|
 | Offline Mode without a Microsoft account | ✅                | ✅                | ✅    | ❌       | ✅             | ✅             | ✅       | ✅             | ❌              |
 | FTB packs                                | ✅                | ✅                | ❌    | ✅       | ✅             | ✅             | ❌       | ✅             | ✅              |
 | Ely.by support                           | ✅                | 🟨¹              | 🟨¹  | 🟨¹     | 🟨¹           | ✅             | 🟨¹     | ❌             | ❌              |
 | Authlib-injector support                 | ✅                | ✅                | ✅    | ✅       | ✅             | ✅            | ❌²      | ❌²            | ❌²             |
-| Custom Authlib-injector jar support      | ❌²               | ✅                | ❌²   | ✅       | ❌²            | ❌²            | ❌²      | ❌²            | ❌²             |
 | Animated Cat Packs & Cropping            | ✅                | ❌                | ❌    | ❌       | ❌             | ❌             | ❌       | ❌             | ❌              |
 | Screenshots saving to the buffer history | ✅                | ❌                | ❌    | ❌       | ❌             | ❌             | ❌       | ❌             | ❌              |
 | Fork                                     | PrismLauncher    | FjordLauncher    | ❌    | PollyMC | PrismLauncher | PrismLauncher | MultiMC | PrismLauncher | PolyMC         |

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -62,13 +62,12 @@
 ## Сравнение
 
 
-| Feature                                           | Freesm  Launcher | Shattered  Prism | HMCL | Fjord   | PollyMC       | ElyPrism      | UltimMC | Prism-Cracked | Prism Launcher |
+| Feature                                           | Freesm  Launcher | Shattered  Prism | HMCL | Fjord   | PollyMC       | PineconeMC    | UltimMC | Prism-Cracked | Prism Launcher |
 |---------------------------------------------------|------------------|------------------|------|---------|---------------|---------------|---------|---------------|----------------|
 | Офлайн-игра без аккаунта Microsoft                | ✅                | ✅                | ✅    | ❌       | ✅             | ✅             | ✅       | ✅             | ❌              |
 | FTB сборки                                        | ✅                | ✅                | ❌    | ✅       | ✅             | ✅             | ❌       | ✅             | ✅              |
 | Поддержка Ely.by                                  | ✅                | 🟨¹              | 🟨¹  | 🟨¹     | 🟨¹           | ✅             | 🟨¹     | ❌             | ❌              |
 | Поддержка Authlib-injector                        | ✅                | ✅                | ✅    | ✅       | ✅             | ✅             | ❌²      | ❌²            | ❌²             |
-| Поддержка кастомного Authlib-injector jar         | ❌²               | ✅                | ❌²   | ✅       | ❌²            | ❌²            | ❌²      | ❌²            | ❌²             |
 | Анимированные Cat паки & кадрирование изображения | ✅                | ❌                | ❌    | ❌       | ❌             | ❌             | ❌       | ❌             | ❌              |
 | Копирование скриншотов из игры в буфер обмена     | ✅                | ❌                | ❌    | ❌       | ❌             | ❌             | ❌       | ❌             | ❌              |
 | Форк                                              | PrismLauncher    | FjordLauncher    | ❌    | PollyMC | PrismLauncher | PrismLauncher | MultiMC | PrismLauncher | PolyMC         |


### PR DESCRIPTION
1. Removed the "Custom Authlib-injector jar support" row because it's basically useless (I think everyone will agree) and I forgot what was the point of it, even though I designed the table
2. Renamed ElyPrism to PineconeMC