### PR TITLE
Restore random username buttons

### DIFF
--- a/launcher/ui/dialogs/ChooseOfflineNameDialog.cpp
+++ b/launcher/ui/dialogs/ChooseOfflineNameDialog.cpp
@@ -20,6 +20,7 @@
 
 #include <QPushButton>
 #include <QRegularExpression>
+#include <QRandomGenerator>
 
 #include "ui_ChooseOfflineNameDialog.h"
 
@@ -73,3 +74,32 @@ void ChooseOfflineNameDialog::on_allowInvalidUsernames_checkStateChanged(const Q
     ui->usernameTextBox->setValidator(checkState == Qt::Checked ? nullptr : m_usernameValidator);
     updateAcceptAllowed(getUsername());
 }
+
+void ChooseOfflineNameDialog::on_randomCharUser_clicked()
+{
+    const QString possibleCharacters("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    const int randomStringLength = 14; 
+    QString randomString;
+    for(int i=0; i<randomStringLength; ++i)
+    {
+       int index = QRandomGenerator::global()->generate() % possibleCharacters.length();
+       QChar nextChar = possibleCharacters.at(index);
+       randomString.append(nextChar);
+    }
+    ui->usernameTextBox->setText(randomString);
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+}
+
+void ChooseOfflineNameDialog::on_randomFullUser_clicked()
+{
+    //todo: maybe make this words configurable and not hardcoded, smh.
+    QList<QString> PossibleUsernameHalves = {"Cookie", "Clicker", "Licker", "Lenny", "Super", "Sakupen", "Sonic", "Geometry", "Mining", "Chicken", "Sculpted", "Random", "Painted", "Fainted", "MadeIn", "Chinese", "Bing", "Hell", "Circles", "Wave", "Dash", "Crafting", "Smelting", "Jockey", "Vase", "Heaven", "Pudding", "Chilling"};
+    int UsernameArrayLength = PossibleUsernameHalves.count();
+    //int indexPossibleHalf = QRandomGenerator::global()->bounded(22);
+    int indexFirstPossibleHalf = QRandomGenerator::global()->bounded(UsernameArrayLength);
+    int indexSecondPossibleHalf = QRandomGenerator::global()->bounded(UsernameArrayLength);
+    QString GeneratedUsername = PossibleUsernameHalves[indexFirstPossibleHalf] + PossibleUsernameHalves[indexSecondPossibleHalf];
+    ui->usernameTextBox->setText(GeneratedUsername);
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+}
+

--- a/launcher/ui/dialogs/ChooseOfflineNameDialog.h
+++ b/launcher/ui/dialogs/ChooseOfflineNameDialog.h
@@ -44,6 +44,10 @@ class ChooseOfflineNameDialog final : public QDialog {
     void on_usernameTextBox_textEdited(const QString& newText) const;
     void on_allowInvalidUsernames_checkStateChanged(Qt::CheckState checkState) const;
 
+   private slots:
+    void on_randomCharUser_clicked();
+    void on_randomFullUser_clicked();
+
    private:
     Ui::ChooseOfflineNameDialog* ui;
     QRegularExpressionValidator* m_usernameValidator;

--- a/launcher/ui/dialogs/ChooseOfflineNameDialog.ui
+++ b/launcher/ui/dialogs/ChooseOfflineNameDialog.ui
@@ -48,6 +48,20 @@
                 </widget>
             </item>
             <item>
+                <widget class="QPushButton" name="randomCharUser">
+                    <property name="text">
+                        <string>Random Characters</string>
+                    </property>
+                </widget>
+            </item>
+            <item>
+                <widget class="QPushButton" name="randomFullUser">
+                    <property name="text">
+                        <string>Random Username</string>
+                    </property>
+                </widget>
+            </item>
+            <item>
                 <widget class="QDialogButtonBox" name="buttonBox">
                     <property name="standardButtons">
                         <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>


### PR DESCRIPTION
Restores random username buttons which were removed due to OfflineLoginDialog being changed to ChooseOfflineNameDialog 
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/Freesmteam/FreesmLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
