### PR TITLE
fix(accounts): distinguish accounts with the same profileId

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -223,6 +223,8 @@ set(MINECRAFT_SOURCES
     minecraft/auth/AccountData.h
     minecraft/auth/AccountList.cpp
     minecraft/auth/AccountList.h
+    minecraft/auth/AccountIdentifier.cpp
+    minecraft/auth/AccountIdentifier.h
     minecraft/auth/AuthSession.cpp
     minecraft/auth/AuthSession.h
     minecraft/auth/AuthStep.h

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -86,11 +86,11 @@ void LaunchController::decideAccount()
     // Select the account to use. If the instance has a specific account set, that will be used. Otherwise, the default account will be used
     auto* accounts = APPLICATION->accounts();
     const auto instanceAccountId = m_instance->settings()->get("InstanceAccountId").toString();
-    const auto instanceAccountIndex = accounts->findAccountByProfileId(instanceAccountId);
-    if (instanceAccountIndex == -1 || instanceAccountId.isEmpty()) {
-        m_accountToUse = accounts->defaultAccount();
+    const auto instanceAccount = accounts->findAccountById(AccountIdentifier{ instanceAccountId });
+    if (instanceAccount.found()) {
+        m_accountToUse = accounts->at(instanceAccount.index);
     } else {
-        m_accountToUse = accounts->at(instanceAccountIndex);
+        m_accountToUse = accounts->defaultAccount();
     }
 
     if (!accounts->anyAccountIsValid()) {
@@ -342,7 +342,7 @@ bool LaunchController::reauthenticateAccount(const MinecraftAccountPtr& account,
         auto* accounts = APPLICATION->accounts();
         const bool isDefault = accounts->defaultAccount() == account;
         const auto accountType = account->accountType();
-        accounts->removeAccount(accounts->index(accounts->findAccountByProfileId(account->profileId())));
+        accounts->removeAccount(accounts->index(accounts->findAccountById(AccountIdentifier{ *account }).index));
         MinecraftAccountPtr newAccount;
         switch (accountType) {
             case AccountType::MSA:

--- a/launcher/UrlUtils.cpp
+++ b/launcher/UrlUtils.cpp
@@ -1,3 +1,5 @@
+#include <QObject>
+
 #include "UrlUtils.h"
 
 bool UrlUtils::isLocalhost(const QUrl& url)
@@ -15,4 +17,38 @@ void UrlUtils::upgradeToHTTPS(QUrl& url)
     if (isUnsafe(url)) {
         url.setScheme("https");
     }
+}
+
+QUrl UrlUtils::httpFromUserInput(QString userInput, QString* errorString)
+{
+    if (errorString) {
+        errorString->clear();
+    }
+
+    userInput = userInput.trimmed();
+
+    bool httpScheme = userInput.startsWith("http://", Qt::CaseInsensitive);
+    bool httpsScheme = userInput.startsWith("https://", Qt::CaseInsensitive);
+
+    if (userInput.contains("://") && !httpsScheme && !httpScheme) {
+        if (errorString) {
+            *errorString = QObject::tr("Invalid URL scheme");
+        }
+        return {};
+    }
+
+    QUrl deducedUrl = QUrl::fromUserInput(userInput);
+
+    if (!deducedUrl.isValid() || deducedUrl.isLocalFile() || deducedUrl.host().isEmpty()) {
+        if (errorString) {
+            *errorString = QObject::tr("Invalid URL");
+        }
+        return {};
+    }
+
+    if (!httpsScheme && !httpScheme) {
+        deducedUrl.setScheme("https");
+    }
+
+    return deducedUrl;
 }

--- a/launcher/UrlUtils.h
+++ b/launcher/UrlUtils.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <QString>
 #include <QUrl>
 
 namespace UrlUtils {
 bool isLocalhost(const QUrl& url);
 bool isUnsafe(const QUrl& url);
 void upgradeToHTTPS(QUrl& url);
-}
+QUrl httpFromUserInput(QString userInput, QString* errorString);
+}  // namespace UrlUtils

--- a/launcher/minecraft/auth/AccountIdentifier.cpp
+++ b/launcher/minecraft/auth/AccountIdentifier.cpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Freesm Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 so5iso4ka <so5iso4ka@icloud.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QSet>
+#include <utility>
+
+#include "MinecraftAccount.h"
+#include "UrlUtils.h"
+
+#include "AccountIdentifier.h"
+
+AccountIdentifier::AccountIdentifier(const QString& str)
+{
+    const auto firstSep = str.indexOf(':');
+    if (firstSep == -1) {
+        m_profileId = str;
+        return;
+    }
+
+    m_profileId = str.left(firstSep);
+
+    const auto secondSep = str.indexOf(':', firstSep + 1);
+    if (secondSep == -1) {
+        m_accountType = str.mid(firstSep + 1);
+        return;
+    }
+
+    m_accountType = str.mid(firstSep + 1, secondSep - firstSep - 1);
+    m_authUrl = str.mid(secondSep + 1);
+}
+
+AccountIdentifier::AccountIdentifier(QString profileId, QString accountType, QString authUrl)
+    : m_profileId(std::move(profileId)), m_accountType(std::move(accountType)), m_authUrl(std::move(authUrl))
+{}
+
+AccountIdentifier::AccountIdentifier(const MinecraftAccount& account)
+    : m_profileId(account.profileId()), m_accountType(account.typeString()), m_authUrl(account.accountData()->authUrl)
+{}
+
+bool AccountIdentifier::isValid() const
+{
+    if (m_profileId.size() != 32)
+        return false;
+
+    static const QSet<QString> validAccountTypes = { "", "msa", "elyby", "custom", "offline" };
+    if (!validAccountTypes.contains(m_accountType))
+        return false;
+
+    if (m_accountType == "custom" && !m_authUrl.isEmpty()) {
+        QString errorString;
+        UrlUtils::httpFromUserInput(m_authUrl, &errorString);
+        if (!errorString.isEmpty())
+            return false;
+    }
+
+    return true;
+}
+
+QString AccountIdentifier::profileId() const
+{
+    return m_profileId;
+}
+
+QString AccountIdentifier::accountType() const
+{
+    return m_accountType;
+}
+
+QString AccountIdentifier::authUrl() const
+{
+    if (m_authUrl.isEmpty())
+        return {};
+    return UrlUtils::httpFromUserInput(m_authUrl, nullptr).toString(QUrl::StripTrailingSlash);
+}
+
+bool AccountIdentifier::matches(const MinecraftAccount& account) const
+{
+    if (!isValid())
+        return false;
+
+    if (account.profileId() != m_profileId)
+        return false;
+
+    if (!m_accountType.isEmpty() && m_accountType != account.typeString())
+        return false;
+
+    if (m_accountType == "custom" && !m_authUrl.isEmpty()) {
+        if (authUrl() != account.accountData()->authUrl)
+            return false;
+    }
+
+    return true;
+}

--- a/launcher/minecraft/auth/AccountIdentifier.h
+++ b/launcher/minecraft/auth/AccountIdentifier.h
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Freesm Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 so5iso4ka <so5iso4ka@icloud.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+
+class MinecraftAccount;
+
+/*!
+ * Account identifier that can disambiguate profile ID conflicts when type/auth URL are present.
+ */
+class AccountIdentifier {
+   public:
+    AccountIdentifier() = delete;
+
+    /*!
+     * Constructs identifier from user provided input.
+     * If input is invalid, isValid() considered to be false.
+     *
+     * @param str "ProfileID[:type[:AuthURL]]" formatted string, where ProfileID is the Minecraft profile ID, type is account type (msa /
+     * elyby / custom / offline) and AuthURL is authlib-injector auth URL, used for matching only custom accounts.
+     * Only first two ':' characters are separators.
+     */
+    explicit AccountIdentifier(const QString& str);
+
+    /*!
+     * Constructs identifier from profile ID, account type and authlib-injector auth URL.
+     *
+     * @param profileId Minecraft profile ID
+     * @param accountType Account type ("msa" / "elyby" / "custom" / "offline" / "")
+     * @param authUrl authlib-injector auth URL, used for matching only custom accounts
+     */
+    explicit AccountIdentifier(QString profileId, QString accountType, QString authUrl = {});
+
+    /*!
+     * Constructs identifier from existing Minecraft account.
+     *
+     * @param account a valid Minecraft account
+     */
+    explicit AccountIdentifier(const MinecraftAccount& account);
+
+    /*!
+     * @return whether the identifier is valid
+     */
+    bool isValid() const;
+
+    /*!
+     * @return profile ID
+     */
+    QString profileId() const;
+
+    /*!
+     * @return account type string
+     */
+    QString accountType() const;
+
+    /*!
+     * @return authlib-injector auth URL
+     */
+    QString authUrl() const;
+
+    /*!
+     * Matches specified account with identifier. Returns false if the identifier is not valid.
+     * Empty account type matches any account with the same profile ID.
+     * For custom accounts, a non-empty auth URL must also match.
+     *
+     * @param account a valid Minecraft account
+     * @return whether the account match this identifier
+     */
+    bool matches(const MinecraftAccount& account) const;
+
+   private:
+    QString m_profileId;
+    QString m_accountType;
+    QString m_authUrl;
+};
+
+enum class AccountFindError { NoError, InvalidId, NotFound, Ambiguous };
+
+struct AccountFindResult {
+    int index = -1;
+    AccountFindError error = AccountFindError::NotFound;
+
+    bool found() const { return index >= 0 && error == AccountFindError::NoError; }
+};

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -39,8 +39,8 @@
 
 #include <QDir>
 #include <QFile>
-#include <QIcon>
 #include <QIODevice>
+#include <QIcon>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -67,15 +67,30 @@ AccountList::AccountList(QObject* parent) : QAbstractListModel(parent)
 
 AccountList::~AccountList() noexcept {}
 
-int AccountList::findAccountByProfileId(const QString& profileId) const
+AccountFindResult AccountList::findAccountById(const AccountIdentifier& id) const
 {
+    if (!id.isValid()) {
+        return { -1, AccountFindError::InvalidId };
+    }
+
+    int idx = -1;
+
     for (int i = 0; i < count(); i++) {
         MinecraftAccountPtr account = at(i);
-        if (account->profileId() == profileId) {
-            return i;
+        if (id.matches(*account)) {
+            if (idx == -1) {
+                idx = i;
+            } else {
+                return { -1, AccountFindError::Ambiguous };
+            }
         }
     }
-    return -1;
+
+    if (idx == -1) {
+        return { -1, AccountFindError::NotFound };
+    }
+
+    return { idx, AccountFindError::NoError };
 }
 
 MinecraftAccountPtr AccountList::getAccountByProfileName(const QString& profileName) const
@@ -120,24 +135,22 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
     connect(account.get(), &MinecraftAccount::changed, this, &AccountList::accountChanged);
     connect(account.get(), &MinecraftAccount::activityChanged, this, &AccountList::accountActivityChanged);
 
-    // override/replace existing account with the same profileId
-    auto profileId = account->profileId();
-    if (profileId.size()) {
-        auto existingAccount = findAccountByProfileId(profileId);
-        if (existingAccount != -1) {
-            qDebug() << "Replacing old account with a new one with the same profile ID!";
+    // override/replace existing account with the same ID
+    auto existingAccount = findAccountById(AccountIdentifier{ *account });
+    if (existingAccount.found()) {
+        qDebug() << "Replacing old account with a new one with the same profile ID!";
 
-            MinecraftAccountPtr existingAccountPtr = m_accounts[existingAccount];
-            m_accounts[existingAccount] = account;
-            if (m_defaultAccount == existingAccountPtr) {
-                m_defaultAccount = account;
-            }
-            // disconnect notifications for changes in the account being replaced
-            existingAccountPtr->disconnect(this);
-            emit dataChanged(index(existingAccount), index(existingAccount, columnCount(QModelIndex()) - 1));
-            onListChanged();
-            return;
+        auto idx = existingAccount.index;
+        MinecraftAccountPtr existingAccountPtr = m_accounts[idx];
+        m_accounts[idx] = account;
+        if (m_defaultAccount == existingAccountPtr) {
+            m_defaultAccount = account;
         }
+        // disconnect notifications for changes in the account being replaced
+        existingAccountPtr->disconnect(this);
+        emit dataChanged(index(idx), index(idx, columnCount(QModelIndex()) - 1));
+        onListChanged();
+        return;
     }
 
     // if we don't have this profileId yet, add the account to the end
@@ -503,11 +516,8 @@ bool AccountList::loadV3(QJsonObject& root)
         QJsonObject accountObj = accountVal.toObject();
         MinecraftAccountPtr account = MinecraftAccount::loadFromJsonV3(accountObj);
         if (account.get() != nullptr) {
-            auto profileId = account->profileId();
-            if (profileId.size()) {
-                if (findAccountByProfileId(profileId) != -1) {
-                    continue;
-                }
+            if (findAccountById(AccountIdentifier{ *account }).found()) {
+                continue;
             }
             connect(account.get(), &MinecraftAccount::changed, this, &AccountList::accountChanged);
             connect(account.get(), &MinecraftAccount::activityChanged, this, &AccountList::accountActivityChanged);
@@ -662,8 +672,7 @@ void AccountList::tryNext()
                     connect(m_currentTask.get(), &Task::succeeded, this, &AccountList::authSucceeded);
                     connect(m_currentTask.get(), &Task::failed, this, &AccountList::authFailed);
                     m_currentTask->start();
-                    qDebug() << "RefreshSchedule: Processing account" << account->profileName() << "with internal ID"
-                             << accountId;
+                    qDebug() << "RefreshSchedule: Processing account" << account->profileName() << "with internal ID" << accountId;
                     return;
                 }
             }

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -35,8 +35,9 @@
 
 #pragma once
 
-#include "minecraft/auth/MinecraftAccount.h"
+#include "minecraft/auth/AccountIdentifier.h"
 #include "minecraft/auth/AuthFlow.h"
+#include "minecraft/auth/MinecraftAccount.h"
 
 #include <QAbstractListModel>
 #include <QObject>
@@ -78,7 +79,7 @@ class AccountList : public QAbstractListModel {
     void addAccount(MinecraftAccountPtr account);
     void removeAccount(QModelIndex index);
     void moveAccount(QModelIndex index, int delta);
-    int findAccountByProfileId(const QString& profileId) const;
+    AccountFindResult findAccountById(const AccountIdentifier& id) const;
     MinecraftAccountPtr getAccountByProfileName(const QString& profileName) const;
     QStringList profileNames() const;
 

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -157,6 +157,8 @@ class MinecraftAccount : public QObject, public Usable {
 
     AccountData* accountData() { return &data; }
 
+    const AccountData* accountData() const { return &data; }
+
     bool shouldRefresh() const;
 
     void fillSession(AuthSessionPtr session, SettingsObject* settings);

--- a/launcher/minecraft/launch/ClaimAccount.cpp
+++ b/launcher/minecraft/launch/ClaimAccount.cpp
@@ -8,7 +8,12 @@ ClaimAccount::ClaimAccount(LaunchTask* parent, AuthSessionPtr session) : LaunchS
 {
     if (session->launchMode == LaunchMode::Normal) {
         auto accounts = APPLICATION->accounts();
-        m_account = accounts->getAccountByProfileName(session->player_name);
+        auto idx = accounts->findAccountById(AccountIdentifier{ session->uuid, session->user_type, session->authlib_injector_auth_url });
+        if (idx.found()) {
+            m_account = accounts->at(idx.index);
+        } else {
+            m_account = nullptr;
+        }
     }
 }
 

--- a/launcher/ui/dialogs/CustomLoginDialog.cpp
+++ b/launcher/ui/dialogs/CustomLoginDialog.cpp
@@ -24,36 +24,6 @@
 #include "UrlUtils.h"
 #include "net/Download.h"
 
-namespace {
-QUrl formUrl(QString userInput, QString& errorString)
-{
-    errorString.clear();
-
-    userInput = userInput.trimmed();
-
-    bool httpScheme = userInput.startsWith("http://", Qt::CaseInsensitive);
-    bool httpsScheme = userInput.startsWith("https://", Qt::CaseInsensitive);
-
-    if (userInput.contains("://") && !httpsScheme && !httpScheme) {
-        errorString = QObject::tr("Invalid URL scheme");
-        return {};
-    }
-
-    QUrl deducedUrl = QUrl::fromUserInput(userInput);
-
-    if (!deducedUrl.isValid() || deducedUrl.isLocalFile() || deducedUrl.host().isEmpty()) {
-        errorString = QObject::tr("Invalid URL");
-        return {};
-    }
-
-    if (!httpsScheme && !httpScheme) {
-        deducedUrl.setScheme("https");
-    }
-
-    return deducedUrl;
-}
-}  // namespace
-
 CustomLoginDialog::CustomLoginDialog(QWidget* parent) : QDialog(parent), ui(new Ui::CustomLoginDialog)
 {
     ui->setupUi(this);
@@ -82,7 +52,7 @@ void CustomLoginDialog::accept()
 {
     QString errorString;
 
-    const QUrl url(formUrl(ui->authUrlTextBox->text(), errorString));
+    const QUrl url(UrlUtils::httpFromUserInput(ui->authUrlTextBox->text(), &errorString));
     if (!url.isValid()) {
         emit onTaskFailed(errorString);
         return;

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -500,8 +500,13 @@ void MinecraftSettingsWidget::saveSettings()
 
                 if (accountIndex != -1) {
                     const MinecraftAccountPtr account = APPLICATION->accounts()->at(accountIndex);
-                    if (account != nullptr)
-                        settings->set("InstanceAccountId", account->profileId());
+                    if (account != nullptr) {
+                        QString id = QString("%1:%2").arg(account->profileId(), account->typeString());
+                        if (account->accountType() == AccountType::Custom) {
+                            id.append(QString(":%1").arg(account->accountData()->authUrl));
+                        }
+                        settings->set("InstanceAccountId", id);
+                    }
                 }
             } else {
                 settings->reset("InstanceAccountId");
@@ -540,7 +545,7 @@ void MinecraftSettingsWidget::updateAccountsMenu(SettingsObject& settings)
 {
     m_ui->instanceAccountSelector->clear();
     auto accounts = APPLICATION->accounts();
-    int accountIndex = accounts->findAccountByProfileId(settings.get("InstanceAccountId").toString());
+    int accountIndex = accounts->findAccountById(AccountIdentifier{ settings.get("InstanceAccountId").toString() }).index;
 
     for (int i = 0; i < accounts->count(); i++) {
         MinecraftAccountPtr account = accounts->at(i);


### PR DESCRIPTION
Currently, the launcher cannot distinguish between different account types that share the same profile ID (for example, pure offline and Drasl account with `PlayerUUIDGeneration = "offline"` and the same username).