### PR TITLE
feat(nix): jvmPack toplevel function init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,12 +68,10 @@
         graalvm-oracle_17
         graalvm-oracle_25
       ];
-
     in {
       inherit openjdk temurin corretto graal-ce graal-unfree;
       allPack = openjdk ++ temurin ++ corretto ++ graal-ce ++ graal-unfree;
     };
-
   in {
     overlays.default = final: prev: {
       freesmlauncher-unwrapped = final.callPackage ./nix/unwrapped.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -38,24 +38,64 @@
     ];
 
     forEachSystem = nixpkgs.lib.genAttrs systems;
+
+    mkJvmPack = pkgs: let
+      openjdk = with pkgs; [
+        openjdk8
+        openjdk17
+        openjdk21
+        openjdk25
+      ];
+
+      temurin = with pkgs.javaPackages.compiler.temurin-bin; [
+        jdk-8
+        jdk-17
+        jdk-21
+        jdk-25
+      ];
+
+      corretto = with pkgs.javaPackages.compiler; [
+        corretto17
+        corretto21
+        corretto25
+      ];
+
+      graal-ce = with pkgs.graalvmPackages; [
+        graalvm-ce
+      ];
+
+      graal-unfree = with pkgs.graalvmPackages; [
+        graalvm-oracle_17
+        graalvm-oracle_25
+      ];
+
+    in {
+      inherit openjdk temurin corretto graal-ce graal-unfree;
+      allPack = openjdk ++ temurin ++ corretto ++ graal-ce ++ graal-unfree;
+    };
+
   in {
     overlays.default = final: prev: {
       freesmlauncher-unwrapped = final.callPackage ./nix/unwrapped.nix {
         inherit nix-filter libnbtplusplus self;
       };
 
-      freesmlauncher = final.callPackage ./nix/wrapper.nix;
+      freesmlauncher = final.callPackage ./nix/wrapper.nix {
+        jvmPack = mkJvmPack final;
+      };
     };
 
     packages = forEachSystem (system: let
       pkgs = import nixpkgs {inherit system;};
+
+      jvmPack = mkJvmPack pkgs;
 
       freesmlauncher-unwrapped = pkgs.callPackage ./nix/unwrapped.nix {
         inherit nix-filter libnbtplusplus self;
       };
 
       freesmlauncher = pkgs.callPackage ./nix/wrapper.nix {
-        inherit freesmlauncher-unwrapped;
+        inherit freesmlauncher-unwrapped jvmPack;
       };
 
       freesmlauncher-unwrapped-debug = freesmlauncher-unwrapped.overrideAttrs {
@@ -67,7 +107,7 @@
         freesmlauncher-unwrapped = freesmlauncher-unwrapped-debug;
       };
     in {
-      inherit freesmlauncher freesmlauncher-unwrapped freesmlauncher-debug freesmlauncher-unwrapped-debug;
+      inherit freesmlauncher freesmlauncher-unwrapped freesmlauncher-debug freesmlauncher-unwrapped-debug jvmPack;
 
       default = freesmlauncher;
     });

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -33,10 +33,12 @@
   jdks ? jvmPack.openjdk,
 }:
 assert lib.assertMsg (
-  if (
-    jdks != jvmPack.openjdk || jdks != jvmPack.temurin || jdks != jvmPack.allPack
-    ) then builtins.trace "used jvmPack does not provide jdk8!" true
-    else true
+  if
+    (
+      jdks != jvmPack.openjdk || jdks != jvmPack.temurin || jdks != jvmPack.allPack
+    )
+  then builtins.trace "used jvmPack does not provide jdk8!" true
+  else true
 ) "";
 assert lib.assertMsg (
   controllerSupport -> stdenv.hostPlatform.isLinux

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -35,7 +35,7 @@
 assert lib.assertMsg (
   if (
     jdks != jvmPack.openjdk || jdks != jvmPack.temurin || jdks != jvmPack.allPack
-    ) then builtins.warn "used jvmPack does not provide jdk8!" true
+    ) then builtins.trace "used jvmPack does not provide jdk8!" true
     else true
 ) "";
 assert lib.assertMsg (

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -35,7 +35,7 @@
 assert lib.assertMsg (
   if
     (
-      jdks != jvmPack.openjdk || jdks != jvmPack.temurin || jdks != jvmPack.allPack
+      jdks != jvmPack.openjdk && jdks != jvmPack.temurin && jdks != jvmPack.allPack
     )
   then builtins.trace "used jvmPack does not provide jdk8!" true
   else true

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -9,10 +9,6 @@
   flite,
   gamemode,
   glfw3-minecraft,
-  jdk17,
-  jdk21,
-  jdk25,
-  jdk8,
   libGL,
   libX11,
   libXcursor,
@@ -33,13 +29,15 @@
   controllerSupport ? stdenv.hostPlatform.isLinux,
   gamemodeSupport ? stdenv.hostPlatform.isLinux,
   textToSpeechSupport ? stdenv.hostPlatform.isLinux,
-  jdks ? [
-    jdk25
-    jdk21
-    jdk17
-    jdk8
-  ],
+  jvmPack,
+  jdks ? jvmPack.openjdk,
 }:
+assert lib.assertMsg (
+  if (
+    jdks != jvmPack.openjdk || jdks != jvmPack.temurin || jdks != jvmPack.allPack
+    ) then builtins.warn "used jvmPack does not provide jdk8!" true
+    else true
+) "";
 assert lib.assertMsg (
   controllerSupport -> stdenv.hostPlatform.isLinux
 ) "controllerSupport only has an effect on Linux.";


### PR DESCRIPTION
so now you can do shyt like `pkgs.freesmlaucnher.override { jdks = jvmPack.allPack; };` to bloat this package even more

jokes aside - `jvmPack` bundles jdks into function and provides `override`-able option for user to choose

<img width="1233" height="1400" alt="image" src="https://github.com/user-attachments/assets/a65677fb-4ded-44b6-9481-76bd3b25e256" />

also looks cleaner btwwwwwwww