### PR TITLE
Show a list of mods required to be enabled or disabled when mod is toggled

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1158,6 +1158,8 @@ SET(LAUNCHER_SOURCES
     ui/dialogs/InstallLoaderDialog.h
     ui/dialogs/ChooseOfflineNameDialog.cpp
     ui/dialogs/ChooseOfflineNameDialog.h
+    ui/dialogs/ModToggleConfirmDialog.cpp
+    ui/dialogs/ModToggleConfirmDialog.h
 
     ui/dialogs/skins/SkinManageDialog.cpp
     ui/dialogs/skins/SkinManageDialog.h
@@ -1331,6 +1333,7 @@ qt_wrap_ui(LAUNCHER_UI
     ui/dialogs/ChooseProviderDialog.ui
     ui/dialogs/skins/SkinManageDialog.ui
     ui/dialogs/ChooseOfflineNameDialog.ui
+    ui/dialogs/ModToggleConfirmDialog.ui
 )
 
 qt_wrap_ui(PRISM_UPDATE_UI

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -57,7 +57,7 @@
 #include "minecraft/mod/ResourceFolderModel.h"
 #include "minecraft/mod/tasks/LocalModParseTask.h"
 #include "modplatform/ModIndex.h"
-#include "ui/dialogs/CustomMessageBox.h"
+#include "ui/dialogs/ModToggleConfirmDialog.h"
 
 ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
@@ -420,42 +420,13 @@ bool ModFolderModel::setResourceEnabled(const QModelIndexList& indexes, EnableAc
     };
 
     if (requiredToEnable.size() > 0 || requiredToDisable.size() > 0) {
-        QString title;
-        QString message;
-        QString noButton;
-        QString yesButton;
-        if (requiredToEnable.size() > 0 && requiredToDisable.size() > 0) {
-            title = tr("Confirm toggle");
-            message = tr("Toggling these mod(s) will cause changes to other mods.\n") +
-                      tr("%n mod(s) will be enabled\n", "", requiredToEnable.size()) +
-                      tr("%n mod(s) will be disabled\n", "", requiredToDisable.size()) +
-                      tr("Do you want to automatically apply these related changes?\nIgnoring them may break the game.");
-            noButton = tr("Only Toggle Selected");
-            yesButton = tr("Toggle Required Mods");
-        } else if (requiredToEnable.size() > 0) {
-            title = tr("Confirm enable");
-            message = tr("The enabled mod(s) require %n mod(s).\n", "", requiredToEnable.size()) +
-                      tr("Would you like to enable them as well?\nIgnoring them may break the game.");
-            noButton = tr("Only Enable Selected");
-            yesButton = tr("Enable Required");
-        } else {
-            title = tr("Confirm disable");
-            message = tr("The disabled mod(s) are required by %n mod(s).\n", "", requiredToDisable.size()) +
-                      tr("Would you like to disable them as well?\nIgnoring them may break the game.");
-            noButton = tr("Only Disable Selected");
-            yesButton = tr("Disable Required");
-        }
+        auto dialog = ModToggleConfirmDialog(nullptr, requiredToEnable, requiredToDisable);
+        auto response = dialog.exec();
 
-        auto box = CustomMessageBox::selectable(nullptr, title, message, QMessageBox::Warning,
-                                                QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::No);
-        box->button(QMessageBox::No)->setText(noButton);
-        box->button(QMessageBox::Yes)->setText(yesButton);
-        auto response = box->exec();
-
-        if (response == QMessageBox::Yes) {
+        if (response == ModToggleConfirmDialog::Accepted) {
             toEnable |= requiredToEnable;
             toDisable |= requiredToDisable;
-        } else if (response == QMessageBox::Cancel) {
+        } else if (response == ModToggleConfirmDialog::Canceled) {
             return false;
         }
     }

--- a/launcher/ui/dialogs/ModToggleConfirmDialog.cpp
+++ b/launcher/ui/dialogs/ModToggleConfirmDialog.cpp
@@ -1,0 +1,128 @@
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QVBoxLayout>
+
+#include "ModToggleConfirmDialog.h"
+#include "ui_ModToggleConfirmDialog.h"
+#include "minecraft/mod/ModFolderModel.h"
+// ToDo: remove these dirty hacks and change translation files
+#include "ui/dialogs/CopyInstanceDialog.h"
+
+/**
+ * Dirty hack to use ModFolderModel context for translation
+ */
+static inline QString translate(const char *s, const char *c = nullptr, int n = -1)
+{
+    return ModFolderModel::staticMetaObject.tr(s, c, n).trimmed();
+}
+
+/**
+ * Even more dirty hack, because ModFolderModel doesn't have translation for "Cancel" button
+ */
+static inline QString translate_cancel(const char *s, const char *c = nullptr, int n = -1)
+{
+    return CopyInstanceDialog::staticMetaObject.tr(s, c, n);
+}
+
+static QString formatMod(Mod* mod)
+{
+    if (mod->version().isEmpty()) {
+        return QString("- %1").arg(mod->name());
+    } else {
+        return QString("- %1 (%2)").arg(mod->name(), mod->version());
+    }
+}
+
+ModToggleConfirmDialog::ModToggleConfirmDialog(QWidget* parent, const QSet<Mod*>& toEnable, const QSet<Mod*>& toDisable)
+    : QDialog(parent), ui(new Ui::ModToggleConfirmDialog)
+{
+    ui->setupUi(this);
+    resize(minimumSizeHint());
+
+    if (toEnable.size() > 0 && toDisable.size() > 0) {
+        setWindowTitle(translate("Confirm toggle"));
+
+        ui->introLabel->setText(translate("Toggling these mod(s) will cause changes to other mods.\n"));
+        ui->toEnableLabel->setText(translate("%n mod(s) will be enabled\n", "", toEnable.size()));
+        ui->toDisableLabel->setText(translate("%n mod(s) will be disabled\n", "", toDisable.size()));
+        ui->questionLabel->setText(translate("Do you want to automatically apply these related changes?\nIgnoring them may break the game."));
+
+        ui->confirmButton->setText(translate("Toggle Required Mods"));
+        ui->rejectButton->setText(translate("Only Toggle Selected"));
+    } else if (toEnable.size() > 0) {
+        setWindowTitle(translate("Confirm enable"));
+
+        ui->toEnableLabel->setText(translate("The enabled mod(s) require %n mod(s).\n", "", toEnable.size()));
+        ui->questionLabel->setText(translate("Would you like to enable them as well?\nIgnoring them may break the game."));
+
+        ui->confirmButton->setText(translate("Enable Required"));
+        ui->rejectButton->setText(translate("Only Enable Selected"));
+    } else {
+        setWindowTitle(translate("Confirm disable"));
+
+        ui->toDisableLabel->setText(translate("The disabled mod(s) are required by %n mod(s).\n", "", toDisable.size()));
+        ui->questionLabel->setText(translate("Would you like to disable them as well?\nIgnoring them may break the game."));
+
+        ui->confirmButton->setText(translate("Disable Required"));
+        ui->rejectButton->setText(translate("Only Disable Selected"));
+    }
+
+    ui->cancelButton->setText(translate_cancel("Cancel"));
+
+    ui->confirmButton->setIcon(style()->standardIcon(QStyle::SP_DialogApplyButton));
+    ui->rejectButton->setIcon(style()->standardIcon(QStyle::SP_DialogCancelButton));
+    ui->cancelButton->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
+
+    if (toEnable.isEmpty() || toDisable.isEmpty())
+    {
+        ui->introLabel->setVisible(false);
+    }
+
+    if (toEnable.isEmpty())
+    {
+        ui->toEnableLabel->setVisible(false);
+        ui->toEnableList->setVisible(false);
+    }
+
+    for (auto mod : toEnable)
+    {
+        ui->toEnableList->addItem(formatMod(mod));
+    }
+
+    if (toDisable.isEmpty())
+    {
+        ui->toDisableLabel->setVisible(false);
+        ui->toDisableList->setVisible(false);
+    }
+
+    for (auto mod : toDisable)
+    {
+        ui->toDisableList->addItem(formatMod(mod));
+    }
+
+    connect(ui->confirmButton, &QPushButton::clicked, this, &ModToggleConfirmDialog::onAcceptButtonClicked);
+    connect(ui->rejectButton, &QPushButton::clicked, this, &ModToggleConfirmDialog::onRejectButtonClicked);
+    connect(ui->cancelButton, &QPushButton::clicked, this, &ModToggleConfirmDialog::onCancelButtonClicked);
+}
+
+ModToggleConfirmDialog::~ModToggleConfirmDialog()
+{
+    delete ui;
+}
+
+void ModToggleConfirmDialog::onAcceptButtonClicked()
+{
+    done(Accepted);
+}
+
+void ModToggleConfirmDialog::onRejectButtonClicked()
+{
+    done(Rejected);
+}
+
+void ModToggleConfirmDialog::onCancelButtonClicked()
+{
+    done(Canceled);
+}

--- a/launcher/ui/dialogs/ModToggleConfirmDialog.h
+++ b/launcher/ui/dialogs/ModToggleConfirmDialog.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+#include "minecraft/mod/Mod.h"
+
+namespace Ui {
+class ModToggleConfirmDialog;
+}
+
+/**
+ * Custom MessageBox for displaying affected mods by other mods toggle.
+ */
+class ModToggleConfirmDialog : public QDialog {
+    Q_OBJECT
+
+   public:
+    ModToggleConfirmDialog(QWidget* parent, const QSet<Mod*>& toEnable, const QSet<Mod*>& toDisable);
+    ~ModToggleConfirmDialog();
+
+    enum ModToggleConfirmCode {
+        Canceled = QDialog::Rejected,
+        Accepted,
+        Rejected,
+    };
+
+   private slots:
+    void onAcceptButtonClicked();
+    void onRejectButtonClicked();
+    void onCancelButtonClicked();
+
+   private:
+    Ui::ModToggleConfirmDialog* ui;
+};

--- a/launcher/ui/dialogs/ModToggleConfirmDialog.ui
+++ b/launcher/ui/dialogs/ModToggleConfirmDialog.ui
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ModToggleConfirmDialog</class>
+ <widget class="QDialog" name="ModToggleConfirmDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>494</width>
+    <height>416</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Confirm toggle</string>
+  </property>
+  <property name="windowIcon">
+   <iconset theme="QIcon::ThemeIcon::DialogWarning"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="introLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Toggling these mod(s) will cause changes to other mods.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="toEnableLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>%n mod(s) will be enabled</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="toEnableList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::DragDropMode::NoDragDrop</enum>
+     </property>
+     <property name="defaultDropAction">
+      <enum>Qt::DropAction::IgnoreAction</enum>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
+     </property>
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+     </property>
+     <property name="horizontalScrollMode">
+      <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+     </property>
+     <property name="movement">
+      <enum>QListView::Movement::Free</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::ResizeMode::Adjust</enum>
+     </property>
+     <property name="supportedDragActions">
+      <set>Qt::DropAction::IgnoreAction</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="toDisableLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>%n mod(s) will be disabled</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="toDisableList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+     </property>
+     <property name="autoScroll">
+      <bool>true</bool>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::DragDropMode::NoDragDrop</enum>
+     </property>
+     <property name="defaultDropAction">
+      <enum>Qt::DropAction::IgnoreAction</enum>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
+     </property>
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+     </property>
+     <property name="horizontalScrollMode">
+      <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+     </property>
+     <property name="movement">
+      <enum>QListView::Movement::Free</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::ResizeMode::Adjust</enum>
+     </property>
+     <property name="supportedDragActions">
+      <set>Qt::DropAction::IgnoreAction</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>16</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="questionLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Do you want to automatically apply these related changes?
+Ignoring them may break the game.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonsLayout">
+     <item>
+      <widget class="QPushButton" name="confirmButton">
+       <property name="text">
+        <string>Toggle Required Mods</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="rejectButton">
+       <property name="text">
+        <string>Only Toggle Selected</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="buttonsSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
A simple QoL addition to "Confirm toggle/enable/disable" MessageBox.

<img width="671" height="296" alt="Message example" src="https://github.com/user-attachments/assets/242a93d0-f571-405e-8d9e-23e21fc42a3c" />
