### PR TITLE
fix(nix): omit FREESMLAUNCHER_JAVA_PATHS when jdks is empty

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -93,7 +93,7 @@ in
     '';
 
     qtWrapperArgs =
-      ["--prefix FREESMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
+      lib.optional (jdks != []) "--prefix FREESMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
       ++ lib.optionals isLinux [
         "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
         "--prefix LD_LIBRARY_PATH : ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"


### PR DESCRIPTION
When I tried overriding the freesmlauncher package to set `jdks = []`, I got:

```
error: Cannot build '/nix/store/ysrqcwzv8zg9sis5linrhpvnc9hyl79d-freesmlauncher-616e092.drv'.
       Reason: builder failed with exit code 1.
       > <stdin>:61:6: error: #error makeCWrapper: Unknown argument PATH
       > <stdin>:62:6: error: #error makeCWrapper: Unknown argument :
       > <stdin>:63:6: error: #error makeCWrapper: Unknown argument /nix/store/...
```

This can be fixed by only setting FREESMLAUNCHER_JAVA_PATHS if the list is not empty.